### PR TITLE
getAll not merging parameters properly

### DIFF
--- a/source/API.js
+++ b/source/API.js
@@ -38,7 +38,7 @@ class API {
 
     const resourceURL = `${this.url}/${name}`
 
-    endpoints.getAll = ({ query={}}, config={} ) => axios.get(resourceURL, Object.assign({ params: { query }, config }))
+    endpoints.getAll = ({ query={}}, config={} ) => axios.get(resourceURL, Object.assign({ params: { query }}, config))
 
     endpoints.getOne = ({ id }, config={}) =>  axios.get(`${resourceURL}/${id}`, config)
 


### PR DESCRIPTION
The implementation with the current code 

```
const getParam = ({ query={}}, config={} ) => {
  return Object.assign({ params: { query }, config });
};

console.log(getParam({query: {page: 1}}, {header: {'Authorization': 'Bearer aef2341122'}}));
```

produces the output

> { params: { query: { page: 1 } },
>   config: { header: { Authorization: 'Bearer aef2341122' } } }

which is not correct. 

Updated code

```
const getParam = ({ query={}}, config={} ) => {
  return Object.assign({ params: { query }}, config);
};

console.log(getParam({query: {page: 1}}, {header: {'Authorization': 'Bearer aef2341122'}}));
```

produces the right output

> { params: { query: { page: 1 } },
>   header: { Authorization: 'Bearer aef2341122' } }

Fixes #9 