### PR TITLE
Removed params from getAll endpoint in API.JS

### DIFF
--- a/source/API.js
+++ b/source/API.js
@@ -38,7 +38,7 @@ class API {
 
     const resourceURL = `${this.url}/${name}`
 
-    endpoints.getAll = ({ params={}}, config={} ) => axios.get(resourceURL, { params }, config)
+    endpoints.getAll = ( config={} ) => axios.get(resourceURL, config)
 
     endpoints.getOne = ({ id }, config={}) =>  axios.get(`${resourceURL}/${id}`, config)
 


### PR DESCRIPTION
GetAll resources call is not working because we don't need to send params in getAll call. Axios Get method requires URL and Config only.
For convenience, an alias has been provided for the GET method.

axios.get(url[, config])  (Its stated in there offical documentation)